### PR TITLE
CurrencyCode отправляется как строка

### DIFF
--- a/src/main/java/org/lanter/lan4gate/Messages/Requests/Assembler/JSONAssembler.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Requests/Assembler/JSONAssembler.java
@@ -69,7 +69,7 @@ public class JSONAssembler {
                         break;
                     }
                     case CurrencyCode:{
-                        object.put(field.getString(), mRequest.getCurrencyCode());
+                        object.put(field.getString(), String.valueOf(mRequest.getCurrencyCode()));
                         break;
                     }
                     case RRN:{

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/RefundOperations/Refund.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/RefundOperations/Refund.java
@@ -9,9 +9,8 @@ public class Refund extends Response {
         setOperationCode(OperationsList.Refund);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.RRN);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/RefundOperations/RefundWithoutRRN.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/RefundOperations/RefundWithoutRRN.java
@@ -9,9 +9,8 @@ public class RefundWithoutRRN extends Response {
         setOperationCode(OperationsList.RefundWithoutRRN);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.RRN);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/FastTrack.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/FastTrack.java
@@ -9,9 +9,8 @@ public class FastTrack extends Response {
         setOperationCode(OperationsList.FastTrack);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.TerminalFeeAmount);
         addOptionalFields(ResponseFieldsList.TerminalID);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/MOTO.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/MOTO.java
@@ -9,9 +9,8 @@ public class MOTO extends Response {
         setOperationCode(OperationsList.MOTO);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.TerminalFeeAmount);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/PreAuth.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/PreAuth.java
@@ -11,9 +11,8 @@ public class PreAuth extends Response {
         setOperationCode(OperationsList.PreAuth);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.TerminalFeeAmount);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/QuickPayment.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/QuickPayment.java
@@ -9,7 +9,7 @@ public class QuickPayment extends Response {
         setOperationCode(OperationsList.QuickPayment);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
     }
 }

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/Sale.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/Sale.java
@@ -9,9 +9,8 @@ public class Sale extends Response {
         setOperationCode(OperationsList.Sale);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.TerminalFeeAmount);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/SalesCompletion.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/SaleOperations/SalesCompletion.java
@@ -9,9 +9,8 @@ public class SalesCompletion extends Response {
         setOperationCode(OperationsList.SalesCompletion);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.TerminalFeeAmount);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/GetCurrentPrinter.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/GetCurrentPrinter.java
@@ -7,6 +7,6 @@ import org.lanter.lan4gate.Messages.Responses.Response;
 public class GetCurrentPrinter extends Response {
     public GetCurrentPrinter() {
         setOperationCode(OperationsList.GetCurrentPrinter);
-        addMandatoryFields(ResponseFieldsList.AdditionalInfo);
+        addOptionalFields(ResponseFieldsList.AdditionalInfo);
     }
 }

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/GetLastOperation.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/GetLastOperation.java
@@ -9,8 +9,8 @@ public class GetLastOperation extends Response {
    public GetLastOperation(OperationsList operationCode) {
        setOperationCode(OperationsList.GetLastOperation);
        addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-       addMandatoryFields(ResponseFieldsList.OriginalOperationCode);
-       addMandatoryFields(ResponseFieldsList.OriginalOperationStatus);
+       addOptionalFields(ResponseFieldsList.OriginalOperationCode);
+       addOptionalFields(ResponseFieldsList.OriginalOperationStatus);
 
        //Так как неизвестна операция, то необходимо забрать поля из используемой
        if (!operationCode.equals(OperationsList.GetLastOperation)) {

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintCommsInfo.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintCommsInfo.java
@@ -7,6 +7,6 @@ import org.lanter.lan4gate.Messages.Responses.Response;
 public class PrintCommsInfo extends Response {
     public PrintCommsInfo() {
         setOperationCode(OperationsList.PrintCommsInfo);
-        addMandatoryFields(ResponseFieldsList.AdditionalInfo);
+        addOptionalFields(ResponseFieldsList.AdditionalInfo);
     }
 }

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintDetailReport.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintDetailReport.java
@@ -9,7 +9,7 @@ public class PrintDetailReport extends Response {
         setOperationCode(OperationsList.PrintDetailReport);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.TerminalID);
+        addOptionalFields(ResponseFieldsList.TerminalID);
 
         addOptionalFields(ResponseFieldsList.TotalAmount);
         addOptionalFields(ResponseFieldsList.CurrencyCode);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintLastReceipt.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintLastReceipt.java
@@ -9,8 +9,8 @@ public class PrintLastReceipt extends Response {
    public PrintLastReceipt(OperationsList operationCode) {
        setOperationCode(OperationsList.PrintLastReceipt);
        addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-       addMandatoryFields(ResponseFieldsList.OriginalOperationCode);
-       addMandatoryFields(ResponseFieldsList.OriginalOperationStatus);
+       addOptionalFields(ResponseFieldsList.OriginalOperationCode);
+       addOptionalFields(ResponseFieldsList.OriginalOperationStatus);
 
        //Так как неизвестна операция, то необходимо забрать поля из используемой
        if(!operationCode.equals(OperationsList.PrintLastReceipt)) {

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintReceiptCopy.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintReceiptCopy.java
@@ -11,8 +11,8 @@ public class PrintReceiptCopy extends Response {
     public PrintReceiptCopy(OperationsList operationCode) {
         setOperationCode(OperationsList.PrintReceiptCopy);
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.OriginalOperationCode);
-        addMandatoryFields(ResponseFieldsList.OriginalOperationStatus);
+        addOptionalFields(ResponseFieldsList.OriginalOperationCode);
+        addOptionalFields(ResponseFieldsList.OriginalOperationStatus);
 
         //Так как неизвестна операция, то необходимо забрать поля из используемой
         if(!operationCode.equals(OperationsList.PrintReceiptCopy)) {

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintSoftInfo.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintSoftInfo.java
@@ -7,6 +7,6 @@ import org.lanter.lan4gate.Messages.Responses.Response;
 public class PrintSoftInfo extends Response {
     public PrintSoftInfo() {
         setOperationCode(OperationsList.PrintSoftInfo);
-        addMandatoryFields(ResponseFieldsList.AdditionalInfo);
+        addOptionalFields(ResponseFieldsList.AdditionalInfo);
     }
 }

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintSummaryReport.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/PrintSummaryReport.java
@@ -9,7 +9,7 @@ public class PrintSummaryReport extends Response {
         setOperationCode(OperationsList.PrintSummaryReport);
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
 
-        addMandatoryFields(ResponseFieldsList.TerminalID);
+        addOptionalFields(ResponseFieldsList.TerminalID);
 
         addOptionalFields(ResponseFieldsList.TotalAmount);
         addOptionalFields(ResponseFieldsList.CurrencyCode);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/SetCurrentPrinter.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/ServiceOperations/SetCurrentPrinter.java
@@ -7,6 +7,6 @@ import org.lanter.lan4gate.Messages.Responses.Response;
 public class SetCurrentPrinter extends Response {
     public SetCurrentPrinter() {
         setOperationCode(OperationsList.SetCurrentPrinter);
-        addMandatoryFields(ResponseFieldsList.AdditionalInfo);
+        addOptionalFields(ResponseFieldsList.AdditionalInfo);
     }
 }

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/VoidOperations/FullVoid.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/VoidOperations/FullVoid.java
@@ -9,9 +9,8 @@ public class FullVoid extends Response {
         setOperationCode(OperationsList.Void);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.RRN);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/VoidOperations/VoidPartialSale.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/VoidOperations/VoidPartialSale.java
@@ -9,9 +9,8 @@ public class VoidPartialSale extends Response {
         setOperationCode(OperationsList.VoidPartialSale);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.TerminalFeeAmount);

--- a/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/VoidOperations/VoidPreAuth.java
+++ b/src/main/java/org/lanter/lan4gate/Messages/Responses/Operations/VoidOperations/VoidPreAuth.java
@@ -9,9 +9,8 @@ public class VoidPreAuth extends Response {
         setOperationCode(OperationsList.VoidPreAuth);
 
         addOptionalFields(ResponseFieldsList.EcrMerchantNumber);
-        addMandatoryFields(ResponseFieldsList.Status);
-        addMandatoryFields(ResponseFieldsList.TotalAmount);
-        addMandatoryFields(ResponseFieldsList.CurrencyCode);
+        addOptionalFields(ResponseFieldsList.TotalAmount);
+        addOptionalFields(ResponseFieldsList.CurrencyCode);
 
         addOptionalFields(ResponseFieldsList.AcquirerFeeAmount);
         addOptionalFields(ResponseFieldsList.RRN);


### PR DESCRIPTION
Мандатные поля заменены на опциональные для всех операций. Связано с тем, что в случае ошибки данные поля могут не прилетать